### PR TITLE
fix: wildcard patten matching over-reach

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,7 +1,7 @@
 export class ForbiddenError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'ValidationError';
+    this.name = 'ForbiddenError';
   }
 }
 

--- a/src/modules/guards/guards.service.ts
+++ b/src/modules/guards/guards.service.ts
@@ -7,6 +7,7 @@ import { getRoomByConnectionId } from '@/modules/room/room.service';
 import { Logger } from 'winston';
 import { KeyPrefix, KeySuffix } from '@/types/state.types';
 import * as cache from '@/modules/guards/guards.cache';
+import { ForbiddenError } from '@/lib/errors';
 
 export function authenticatedSessionGuard(session: Session): boolean {
   if (!session.clientId) {
@@ -50,7 +51,7 @@ export function permissionsGuard(
     }
   }
 
-  throw new Error(`Client not permitted to perform "${permission}" in "${roomId}"`);
+  throw new ForbiddenError(`Client not permitted to perform "${permission}" in "${roomId}"`);
 }
 
 export async function roomMemberGuard(

--- a/src/modules/permissions/permissions.service.ts
+++ b/src/modules/permissions/permissions.service.ts
@@ -19,19 +19,25 @@ export function findWildcardMatch(
   const roomParts = roomId.split(':');
 
   for (const key of Object.keys(permissions)) {
-    const keyParts = key.split(':');
     let matches = true;
 
-    for (let i = 0; i < roomParts.length; i++) {
-      const keyPart = keyParts[i] || keyParts[keyParts.length - 1];
+    const keyParts = key.split(':');
 
+    for (let i = 0; i < roomParts.length; i++) {
+      // If keyParts[i] is undefined (e.g., fewer parts in the key), fall back to the last part.
+      // Eg. `room:*` must match `room:one` and `room:one:two`
+      const keyPart = keyParts[i] ?? keyParts[keyParts.length - 1];
+
+      // If `keyPart` doesn't match `roomParts[i]` or its not a wildcard
+      // Break and fail
       if (keyPart !== '*' && keyPart !== roomParts[i]) {
         matches = false;
         break;
       }
     }
 
-    if (matches) {
+    // Only return if the match is valid and doesn't overreach
+    if (matches && keyParts.length <= roomParts.length) {
       return permissions[key];
     }
   }

--- a/test/modules/guards.test.ts
+++ b/test/modules/guards.test.ts
@@ -9,6 +9,7 @@ import {
 import { RedisClient } from '@/lib/redis';
 import { getMockSession } from '@/modules/session/session.mock';
 import { getLogger } from '@/util/logger';
+import { ForbiddenError } from '@/lib/errors';
 
 const logger = getLogger('');
 
@@ -87,7 +88,12 @@ describe('guards.service', () => {
         expect(permissionsGuard('room2', DsPermission.SUBSCRIBE, permissions)).toBe(true);
       });
 
-      it('returns true if room-specific wildcard permissions include the requested permission', () => {
+      /**
+       * This should NOT pass.
+       * Wildcards have to match one or more specific entries.
+       * In this case, "room1:*" does not match "room1", leaving here for visibility
+       */
+      it.skip('returns true if room-specific wildcard permissions include the requested permission', () => {
         const permissions: DsPermissions = {
           'room1:*': ['subscribe', 'publish']
         };
@@ -139,82 +145,102 @@ describe('guards.service', () => {
     });
 
     describe('error', () => {
-      it('throws an error if permissions do not include the specific requested permission', () => {
+      it('throws ForbiddenError if permissions do not include the specific requested permission', () => {
         const permissions = ['subscribe', 'publish'];
 
         expect(() => permissionsGuard('room1', DsPermission.HISTORY, permissions)).toThrow(
-          /not permitted/
+          ForbiddenError
         );
       });
 
-      it('throws an error if the wildcard pattern does not match the queried room structure', () => {
+      it('throws ForbiddenError if the wildcard pattern does not match the queried room structure', () => {
         const permissions: DsPermissions = {
           'room1:*:user': ['subscribe', 'publish']
         };
 
         expect(() =>
           permissionsGuard('room1:one:two:user', DsPermission.PUBLISH, permissions)
-        ).toThrow(/not permitted/);
+        ).toThrow(ForbiddenError);
       });
 
-      it('throws an error if the wildcard pattern does not match the queried room structure', () => {
+      it('throws ForbiddenError if the wildcard pattern does not match the queried room structure', () => {
         const permissions: DsPermissions = {
           'room1:*:user': ['subscribe', 'publish']
         };
 
         expect(() =>
           permissionsGuard('room1:one:user:123', DsPermission.PUBLISH, permissions)
-        ).toThrow(/not permitted/);
+        ).toThrow(ForbiddenError);
       });
 
-      it('throws an error if the wildcard pattern does not match the queried room structure', () => {
+      it('throws ForbiddenError if the wildcard pattern does not match the queried room structure', () => {
         const permissions: DsPermissions = {
           'room1:*:user': ['subscribe', 'publish']
         };
 
         expect(() =>
           permissionsGuard('room1:one:admin', DsPermission.PUBLISH, permissions)
-        ).toThrow(/not permitted/);
+        ).toThrow(ForbiddenError);
       });
 
-      it('throws an error if the client is not permitted to perform the action in the specified room', () => {
+      it('throws ForbiddenError if the client is not permitted to perform the action in the specified room', () => {
         const permissions: DsPermissions = {
           room1: ['subscribe']
         };
 
         expect(() => permissionsGuard('room1', DsPermission.PUBLISH, permissions)).toThrow(
-          /not permitted/
+          ForbiddenError
         );
       });
 
-      it('throws an error if the client is not permitted to perform the action even when global wildcard partially matches', () => {
+      it('throws ForbiddenError if the client is not permitted to perform the action even when global wildcard partially matches', () => {
         const permissions: DsPermissions = {
           '*': ['subscribe', 'publish'],
           room2: ['subscribe']
         };
 
         expect(() => permissionsGuard('room2', DsPermission.PUBLISH, permissions)).toThrow(
-          /not permitted/
+          ForbiddenError
         );
       });
 
-      it('throws an error if the client is not permitted to perform the action despite global wildcard matching other permissions', () => {
+      it('throws ForbiddenError if the client is not permitted to perform the action despite global wildcard matching other permissions', () => {
         const permissions: DsPermissions = {
           '*': ['subscribe', 'publish']
         };
 
         expect(() => permissionsGuard('room1', DsPermission.PRESENCE, permissions)).toThrow(
-          /not permitted/
+          ForbiddenError
         );
       });
 
-      it('throws an error if the client is not permitted to perform the action despite room-specific wildcard permissions', () => {
+      it('throws ForbiddenError if the client is not permitted to perform the action despite room-specific wildcard permissions', () => {
         const permissions: DsPermissions = {
           room1: ['*']
         };
 
         expect(() => permissionsGuard('room2', DsPermission.PRESENCE, permissions)).toThrow(
-          /not permitted/
+          ForbiddenError
+        );
+      });
+
+      it('throws ForbiddenError if room is not found in permissions', () => {
+        const permissions: DsPermissions = {
+          'chat:one:test': ['subscribe']
+        };
+
+        expect(() => permissionsGuard('config', DsPermission.PRESENCE, permissions)).toThrow(
+          ForbiddenError
+        );
+      });
+
+      it('throws ForbiddenError if room is only partially matched in permissions', () => {
+        const permissions: DsPermissions = {
+          'user:123': ['subscribe']
+        };
+
+        expect(() => permissionsGuard('user', DsPermission.SUBSCRIBE, permissions)).toThrow(
+          ForbiddenError
         );
       });
 
@@ -226,17 +252,7 @@ describe('guards.service', () => {
 
         expect(() =>
           permissionsGuard('room1:one:test', DsPermission.PRESENCE, permissions)
-        ).toThrow(/not permitted/);
-      });
-
-      it('should something', () => {
-        const permissions: DsPermissions = {
-          'chat:one:test': ['subscribe']
-        };
-
-        expect(() => permissionsGuard('config', DsPermission.PRESENCE, permissions)).toThrow(
-          /not permitted/
-        );
+        ).toThrow(ForbiddenError);
       });
     });
   });


### PR DESCRIPTION
Currently pattern matching is over-reaching causing unintended matches. For example...

`room1:*` matches `room1`

Fix: Add overreach conditional check to wildcard pattern matching